### PR TITLE
Migrated to Bevy 0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,26 +1,23 @@
 [package]
 name = "bevy_debug_grid"
 description = "A bevy plugin for creating grids, for debugging purposes"
-version = "0.6.0"
+version = "0.7.0"
 repository = "https://github.com/romenjelly/bevy_debug_grid"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
-exclude = [
-    "/examples/",
-    "/assets/",
-]
+exclude = ["/examples/", "/assets/"]
 
 [dependencies]
-bevy = { version = "0.14", default-features = false, features = [
+bevy = { version = "0.15", default-features = false, features = [
     "bevy_render",
     "bevy_pbr",
     "bevy_asset",
 ] }
 
 [dev-dependencies]
-bevy = "0.14"
-bevy_spectator = "0.6"
+bevy = "0.15"
+bevy_spectator = "0.7"
 
 [[example]]
 name = "default_cube"

--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ commands.spawn((
         // Alpha mode for all components
         alpha_mode: AlphaMode::Opaque,
     },
-    TransformBundle::default(),
-    VisibilityBundle::default(),
+    Transform::default(),
+    Visibility::default(),
 ));
 ```
 
@@ -185,7 +185,7 @@ fn spawn_main_camera(
     mut commands: Commands,
 ) {
     commands.spawn((
-        Camera3dBundle::default(),
+        Camera3d::default(),
         MainCamera,
     ));
 }
@@ -249,6 +249,7 @@ Adding a `RenderLayers` component to an entity with a `Grid` will ensure that al
 
 | Bevy Version | Plugin Version |
 |:------------:|:--------------:|
+|    `0.15`    |  `0.7`         |
 |    `0.14`    |  `0.6`         |
 |    `0.13`    |  `0.5`         |
 |    `0.12`    |  `0.3.0-0.4.1` |

--- a/examples/changing_grid.rs
+++ b/examples/changing_grid.rs
@@ -1,4 +1,4 @@
-use bevy::{prelude::*, color::palettes::tailwind};
+use bevy::{color::palettes::tailwind, prelude::*};
 use bevy_debug_grid::*;
 use bevy_spectator::*;
 use std::f32;
@@ -28,14 +28,11 @@ fn main() {
 
 pub fn spawn_camera(mut commands: Commands) {
     commands.spawn((
-        Camera3dBundle {
-            transform: Transform::from_xyz(-4.0_f32, 12.0_f32, 12.0_f32).looking_at(Vec3::ZERO, Vec3::Y),
-            ..default()
-        },
+        Transform::from_xyz(-4.0_f32, 12.0_f32, 12.0_f32).looking_at(Vec3::ZERO, Vec3::Y),
+        Camera3d::default(),
         Spectator,
     ));
 }
-
 
 fn spawn_demonstration_objects(mut commands: Commands) {
     let period = 4.0_f32;
@@ -45,11 +42,8 @@ fn spawn_demonstration_objects(mut commands: Commands) {
 
     // Changing count, red
     commands.spawn((
-        TransformBundle {
-            local: Transform::from_xyz(-spacing, height_offset, -depth_offset),
-            ..default()
-        },
-        VisibilityBundle::default(),
+        Transform::from_xyz(-spacing, height_offset, -depth_offset),
+        Visibility::default(),
         Grid {
             color: Color::Srgba(tailwind::RED_500),
             ..default()
@@ -59,11 +53,8 @@ fn spawn_demonstration_objects(mut commands: Commands) {
     ));
     // Changing spacing, green
     commands.spawn((
-        TransformBundle {
-            local: Transform::from_xyz(0.0_f32, height_offset, -depth_offset),
-            ..default()
-        },
-        VisibilityBundle::default(),
+        Transform::from_xyz(0.0_f32, height_offset, -depth_offset),
+        Visibility::default(),
         Grid {
             color: Color::Srgba(tailwind::GREEN_500),
             ..default()
@@ -76,11 +67,8 @@ fn spawn_demonstration_objects(mut commands: Commands) {
     ));
     // Changing count and spacing, blue
     commands.spawn((
-        TransformBundle {
-            local: Transform::from_xyz(spacing, height_offset, -depth_offset),
-            ..default()
-        },
-        VisibilityBundle::default(),
+        Transform::from_xyz(spacing, height_offset, -depth_offset),
+        Visibility::default(),
         Grid {
             color: Color::Srgba(tailwind::BLUE_500),
             ..default()
@@ -94,11 +82,8 @@ fn spawn_demonstration_objects(mut commands: Commands) {
     ));
     // Changing sub-count, cyan and magenta
     commands.spawn((
-        TransformBundle {
-            local: Transform::from_xyz(-spacing, height_offset, depth_offset),
-            ..default()
-        },
-        VisibilityBundle::default(),
+        Transform::from_xyz(-spacing, height_offset, depth_offset),
+        Visibility::default(),
         Grid {
             color: Color::Srgba(tailwind::CYAN_500),
             ..default()
@@ -112,11 +97,8 @@ fn spawn_demonstration_objects(mut commands: Commands) {
     ));
     // Changing color
     commands.spawn((
-        TransformBundle {
-            local: Transform::from_xyz(0.0_f32, height_offset, depth_offset),
-            ..default()
-        },
-        VisibilityBundle::default(),
+        Transform::from_xyz(0.0_f32, height_offset, depth_offset),
+        Visibility::default(),
         Grid {
             color: Color::WHITE,
             ..default()
@@ -126,11 +108,8 @@ fn spawn_demonstration_objects(mut commands: Commands) {
     ));
     // Changing sub-color, yellow
     commands.spawn((
-        TransformBundle {
-            local: Transform::from_xyz(spacing, height_offset, depth_offset),
-            ..default()
-        },
-        VisibilityBundle::default(),
+        Transform::from_xyz(spacing, height_offset, depth_offset),
+        Visibility::default(),
         Grid {
             color: Color::Srgba(tailwind::YELLOW_500),
             ..default()

--- a/examples/changing_grid_axis.rs
+++ b/examples/changing_grid_axis.rs
@@ -11,7 +11,11 @@ fn main() {
             SpectatorPlugin,
             DebugGridPlugin::without_floor_grid(),
         ))
-        .add_systems(Startup, (default_cube::spawn_camera, spawn_demonstration_grid))
+        .add_plugins(DebugGridPlugin::without_floor_grid())
+        .add_systems(
+            Startup,
+            (default_cube::spawn_camera, spawn_demonstration_grid),
+        )
         .add_systems(Update, change_axis_color)
         .run();
 }
@@ -24,13 +28,13 @@ fn spawn_demonstration_grid(mut commands: Commands) {
         Grid::default(),
         GridAxis::new_empty(),
         ChangingAxis,
-        TransformBundle::default(),
-        VisibilityBundle::default(),
+        Transform::default(),
+        Visibility::default(),
     ));
 }
 
 fn change_axis_color(mut query: Query<&mut GridAxis, With<ChangingAxis>>, time: Res<Time>) {
-    let elapsed = time.elapsed_seconds() * 0.25_f32;
+    let elapsed = time.elapsed_secs() * 0.25_f32;
     let selected_axis = (elapsed % 4.0_f32) as usize;
     let axis_color = Some(Color::hsl(
         (elapsed % 1.0_f32) * 360.0_f32,

--- a/examples/default_cube.rs
+++ b/examples/default_cube.rs
@@ -7,7 +7,7 @@ use bevy_spectator::*;
 fn main() {
     App::new()
         .add_plugins((
-            DefaultPlugins, 
+            DefaultPlugins,
             SpectatorPlugin,
             DebugGridPlugin::with_floor_grid(),
         ))
@@ -17,10 +17,8 @@ fn main() {
 
 pub fn camera_bundle() -> impl Bundle {
     (
-        Camera3dBundle {
-            transform: Transform::from_xyz(7.0_f32, 3.5_f32, 4.0_f32).looking_at(Vec3::Y * 0.5_f32, Vec3::Y),
-            ..default()
-        },
+        Transform::from_xyz(7.0_f32, 3.5_f32, 4.0_f32).looking_at(Vec3::Y * 0.5_f32, Vec3::Y),
+        Camera3d::default(),
         Spectator,
     )
 }
@@ -35,16 +33,15 @@ fn default_cube(
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
     // Cube
-    commands.spawn(PbrBundle {
-        mesh: meshes.add(Cuboid::new(1.0_f32, 1.0_f32, 1.0_f32)),
-        material: materials.add(StandardMaterial::from(Color::WHITE)),
-        transform: Transform::from_xyz(0.0_f32, 0.5_f32, 0.0_f32),
-        ..default()
-    });
+    commands.spawn((
+        Mesh3d(meshes.add(Cuboid::new(1.0_f32, 1.0_f32, 1.0_f32))),
+        MeshMaterial3d(materials.add(StandardMaterial::from(Color::WHITE))),
+        Transform::from_xyz(0.0_f32, 0.5_f32, 0.0_f32),
+    ));
 
     // Point light
-    commands.spawn(PointLightBundle {
-        transform: Transform::from_xyz(4.0_f32, 4.0_f32, 4.0_f32),
-        ..default()
-    });
+    commands.spawn((
+        PointLight::default(),
+        Transform::from_xyz(4.0_f32, 4.0_f32, 4.0_f32),
+    ));
 }

--- a/examples/dynamic_floor_grid.rs
+++ b/examples/dynamic_floor_grid.rs
@@ -16,9 +16,9 @@ const COLOR_Z_END: Srgba = tailwind::YELLOW_500;
 fn main() {
     App::new()
         .add_plugins((
-            //DefaultPlugins,
+            DefaultPlugins,
             SpectatorPlugin,
-            //DebugGridPlugin::without_floor_grid(),
+            DebugGridPlugin::without_floor_grid(),
         ))
         .add_systems(
             Startup,

--- a/examples/dynamic_floor_grid.rs
+++ b/examples/dynamic_floor_grid.rs
@@ -1,4 +1,4 @@
-use bevy::{prelude::*, color::palettes::tailwind};
+use bevy::{color::palettes::tailwind, prelude::*};
 use bevy_debug_grid::*;
 use bevy_spectator::*;
 
@@ -16,13 +16,17 @@ const COLOR_Z_END: Srgba = tailwind::YELLOW_500;
 fn main() {
     App::new()
         .add_plugins((
-            DefaultPlugins,
+            //DefaultPlugins,
             SpectatorPlugin,
-            DebugGridPlugin::without_floor_grid(),
+            //DebugGridPlugin::without_floor_grid(),
         ))
         .add_systems(
             Startup,
-            (spawn_floor_grid, default_cube::spawn_camera, spawn_center_sphere),
+            (
+                spawn_floor_grid,
+                default_cube::spawn_camera,
+                spawn_center_sphere,
+            ),
         )
         .add_systems(Update, (move_floor_grid, change_axis_color))
         .run();
@@ -33,11 +37,10 @@ fn spawn_center_sphere(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
-    commands.spawn(PbrBundle {
-        mesh: meshes.add(Sphere::default()),
-        material: materials.add(StandardMaterial::from(Color::WHITE)),
-        ..default()
-    });
+    commands.spawn((
+        Mesh3d(meshes.add(Sphere::default())),
+        MeshMaterial3d(materials.add(StandardMaterial::from(Color::WHITE))),
+    ));
 }
 
 fn spawn_floor_grid(mut commands: Commands) {
@@ -57,30 +60,34 @@ fn spawn_floor_grid(mut commands: Commands) {
             alignment: GridAlignment::X,
             ..default()
         },
-        TransformBundle::default(),
-        VisibilityBundle::default(),
+        Transform::default(),
+        Visibility::default(),
     ));
 
     // Point light
-    commands.spawn(PointLightBundle {
-        transform: Transform::from_xyz(4.0_f32, 4.0_f32, 4.0_f32),
-        ..default()
-    });
+    commands.spawn((
+        Transform::from_xyz(4.0_f32, 4.0_f32, 4.0_f32),
+        PointLight::default(),
+    ));
 }
 
 fn move_floor_grid(mut query: Query<&mut TrackedGrid>, time: Res<Time>) {
     for mut grid in query.iter_mut() {
-        grid.offset = time.elapsed_seconds().sin();
+        grid.offset = time.elapsed_secs().sin();
     }
 }
 
 fn lerp_color(lhs: Srgba, rhs: Srgba, factor: f32) -> Color {
-    let subbed = Srgba::rgb(rhs.red - lhs.red, rhs.green - lhs.green, rhs.blue - lhs.blue);
+    let subbed = Srgba::rgb(
+        rhs.red - lhs.red,
+        rhs.green - lhs.green,
+        rhs.blue - lhs.blue,
+    );
     Color::Srgba(lhs + subbed * factor)
 }
 
 fn change_axis_color(mut query: Query<&mut GridAxis, With<TrackedGrid>>, time: Res<Time>) {
-    let factor = ((time.elapsed_seconds()).cos() + 1.0_f32) * 0.5_f32;
+    let factor = ((time.elapsed_secs()).cos() + 1.0_f32) * 0.5_f32;
     for mut axis in query.iter_mut() {
         axis.x = Some(lerp_color(COLOR_X_START, COLOR_X_END, factor));
         axis.y = Some(lerp_color(COLOR_Y_START, COLOR_Y_END, factor));

--- a/examples/moving_grid.rs
+++ b/examples/moving_grid.rs
@@ -1,4 +1,4 @@
-use bevy::{prelude::*, color::palettes::tailwind};
+use bevy::{color::palettes::tailwind, prelude::*};
 use bevy_debug_grid::*;
 use bevy_spectator::*;
 use std::f32;
@@ -12,7 +12,10 @@ fn main() {
             SpectatorPlugin,
             DebugGridPlugin::with_floor_grid(),
         ))
-        .add_systems(Startup, (changing_grid::spawn_camera, spawn_demonstration_objects))
+        .add_systems(
+            Startup,
+            (changing_grid::spawn_camera, spawn_demonstration_objects),
+        )
         .add_systems(Update, (move_objects, spin_objects))
         .run();
 }
@@ -36,11 +39,8 @@ fn spawn_demonstration_objects(
 
     // Moving mesh, red
     commands.spawn((
-        PbrBundle {
-            mesh: meshes.add(Cuboid::default()),
-            material: materials.add(StandardMaterial::from(Color::WHITE)),
-            ..default()
-        },
+        Mesh3d(meshes.add(Cuboid::default())),
+        MeshMaterial3d(materials.add(StandardMaterial::from(Color::WHITE))),
         Moving {
             origin: Vec3::new(-spacing_offset, height_offset, -depth_offset),
         },
@@ -51,12 +51,9 @@ fn spawn_demonstration_objects(
     ));
     // Spinning mesh, green
     commands.spawn((
-        PbrBundle {
-            mesh: meshes.add(Capsule3d::default()),
-            material: materials.add(StandardMaterial::from(Color::WHITE)),
-            transform: Transform::from_xyz(0.0_f32, height_offset, -depth_offset),
-            ..default()
-        },
+        Mesh3d(meshes.add(Capsule3d::default())),
+        MeshMaterial3d(materials.add(StandardMaterial::from(Color::WHITE))),
+        Transform::from_xyz(0.0_f32, height_offset, -depth_offset),
         Grid {
             color: Color::Srgba(tailwind::GREEN_500),
             ..default()
@@ -65,11 +62,8 @@ fn spawn_demonstration_objects(
     ));
     // Moving and spinning mesh, blue
     commands.spawn((
-        PbrBundle {
-            mesh: meshes.add(Torus::default()),
-            material: materials.add(StandardMaterial::from(Color::WHITE)),
-            ..default()
-        },
+        Mesh3d(meshes.add(Torus::default())),
+        MeshMaterial3d(materials.add(StandardMaterial::from(Color::WHITE))),
         Grid {
             color: Color::Srgba(tailwind::BLUE_500),
             ..default()
@@ -81,16 +75,15 @@ fn spawn_demonstration_objects(
     ));
     // Moving grid, cyan
     commands
-        .spawn(PbrBundle {
-            mesh: meshes.add(Cuboid::default()),
-            material: materials.add(StandardMaterial::from(Color::WHITE)),
-            transform: Transform::from_xyz(-spacing_offset, height_offset, depth_offset),
-            ..default()
-        })
+        .spawn((
+            Mesh3d(meshes.add(Cuboid::default())),
+            MeshMaterial3d(materials.add(StandardMaterial::from(Color::WHITE))),
+            Transform::from_xyz(-spacing_offset, height_offset, depth_offset),
+        ))
         .with_children(|child| {
             child.spawn((
-                TransformBundle::default(),
-                VisibilityBundle::default(),
+                Transform::default(),
+                Visibility::default(),
                 Grid {
                     color: Color::Srgba(tailwind::CYAN_500),
                     ..default()
@@ -100,16 +93,15 @@ fn spawn_demonstration_objects(
         });
     // Spinning grid, magenta
     commands
-        .spawn(PbrBundle {
-            mesh: meshes.add(Capsule3d::default()),
-            material: materials.add(StandardMaterial::from(Color::WHITE)),
-            transform: Transform::from_xyz(0.0_f32, height_offset, depth_offset),
-            ..default()
-        })
+        .spawn((
+            Mesh3d(meshes.add(Capsule3d::default())),
+            MeshMaterial3d(materials.add(StandardMaterial::from(Color::WHITE))),
+            Transform::from_xyz(0.0_f32, height_offset, depth_offset),
+        ))
         .with_children(|child| {
             child.spawn((
-                TransformBundle::default(),
-                VisibilityBundle::default(),
+                Transform::default(),
+                Visibility::default(),
                 Grid {
                     color: Color::Srgba(tailwind::VIOLET_500),
                     ..default()
@@ -119,16 +111,15 @@ fn spawn_demonstration_objects(
         });
     // Moving and spinning grid, yellow
     commands
-        .spawn(PbrBundle {
-            mesh: meshes.add(Torus::default()),
-            material: materials.add(StandardMaterial::from(Color::WHITE)),
-            transform: Transform::from_xyz(spacing_offset, height_offset, depth_offset),
-            ..default()
-        })
+        .spawn((
+            Mesh3d(meshes.add(Torus::default())),
+            MeshMaterial3d(materials.add(StandardMaterial::from(Color::WHITE))),
+            Transform::from_xyz(spacing_offset, height_offset, depth_offset),
+        ))
         .with_children(|child| {
             child.spawn((
-                TransformBundle::default(),
-                VisibilityBundle::default(),
+                Transform::default(),
+                Visibility::default(),
                 Grid {
                     color: Color::Srgba(tailwind::YELLOW_500),
                     ..default()
@@ -139,10 +130,10 @@ fn spawn_demonstration_objects(
         });
 
     // Point light
-    commands.spawn(PointLightBundle {
-        transform: Transform::from_xyz(4.0_f32, 4.0_f32, 4.0_f32),
-        ..default()
-    });
+    commands.spawn((
+        Transform::from_xyz(4.0_f32, 4.0_f32, 4.0_f32),
+        PointLight::default(),
+    ));
 }
 
 fn move_objects(mut query: Query<(&mut Transform, &Moving)>, time: Res<Time>) {

--- a/examples/render_layers.rs
+++ b/examples/render_layers.rs
@@ -1,6 +1,6 @@
 use bevy::{
-    prelude::*,
     color::palettes::tailwind,
+    prelude::*,
     render::{
         camera::{ClearColorConfig, RenderTarget},
         render_resource::{
@@ -84,17 +84,14 @@ fn setup(
 
     // Top render layer camera
     commands.spawn((
-        Camera3dBundle {
-            camera: Camera {
-                clear_color: ClearColorConfig::Custom(Color::Srgba(tailwind::GRAY_500)),
-                order: -1,
-                target: RenderTarget::Image(top_image_handle.clone()),
-                ..default()
-            },
-            transform: Transform::from_xyz(0.0_f32, 8.0_f32, 0.0_f32)
-                .looking_at(Vec3::ZERO, Vec3::Y),
+        Camera3d::default(),
+        Camera {
+            clear_color: ClearColorConfig::Custom(Color::Srgba(tailwind::GRAY_500)),
+            order: -1,
+            target: RenderTarget::Image(top_image_handle.clone()),
             ..default()
         },
+        Transform::from_xyz(0.0_f32, 8.0_f32, 0.0_f32).looking_at(Vec3::ZERO, Vec3::Y),
         RenderLayers::layer(TOP_LAYER),
     ));
 
@@ -104,8 +101,8 @@ fn setup(
             color: Color::Srgba(tailwind::ORANGE_500.with_alpha(Grid::DEFAULT_ALPHA)),
             ..default()
         },
-        VisibilityBundle::default(),
-        TransformBundle::default(),
+        Visibility::default(),
+        Transform::default(),
         RenderLayers::layer(TOP_LAYER),
     ));
 
@@ -116,17 +113,14 @@ fn setup(
     // The entity id is saved to later pass it to the grid tracking override
     let secondary_camera_entity = commands
         .spawn((
-            Camera3dBundle {
-                camera: Camera {
-                    clear_color: ClearColorConfig::Custom(Color::Srgba(tailwind::GRAY_500)),
-                    order: -1,
-                    target: RenderTarget::Image(bottom_image_handle.clone()),
-                    ..default()
-                },
-                transform: Transform::from_xyz(-4.0_f32, 2.0_f32, 4.0_f32)
-                    .looking_at(Vec3::Y, Vec3::Y),
+            Camera3d::default(),
+            Camera {
+                clear_color: ClearColorConfig::Custom(Color::Srgba(tailwind::GRAY_500)),
+                order: -1,
+                target: RenderTarget::Image(bottom_image_handle.clone()),
                 ..default()
             },
+            Transform::from_xyz(-4.0_f32, 2.0_f32, 4.0_f32).looking_at(Vec3::Y, Vec3::Y),
             RenderLayers::layer(BOTTOM_LAYER),
         ))
         .id();
@@ -148,67 +142,62 @@ fn setup(
             tracking_override: Some(secondary_camera_entity),
             ..default()
         },
-        VisibilityBundle::default(),
-        TransformBundle::default(),
+        Visibility::default(),
+        Transform::default(),
         RenderLayers::layer(BOTTOM_LAYER),
     ));
 
     // Cube in the center
     commands.spawn((
-        PbrBundle {
-            mesh: meshes.add(Mesh::from(Cuboid::new(1.0_f32, 1.0, 1.0))),
-            material: materials.add(StandardMaterial::default()),
-            transform: Transform::from_xyz(0.0_f32, 0.75_f32, 0.0_f32),
-            ..default()
-        },
+        (
+            Mesh3d(meshes.add(Mesh::from(Cuboid::new(1.0_f32, 1.0, 1.0)))),
+            MeshMaterial3d(materials.add(StandardMaterial::default())),
+            Transform::from_xyz(0.0_f32, 0.75_f32, 0.0_f32),
+        ),
         Floating,
         // Make the cube visible on all relevant render layers
         RenderLayers::default().with(TOP_LAYER).with(BOTTOM_LAYER),
     ));
 
     // Lighting
-    commands.spawn(PointLightBundle {
-        transform: Transform::from_translation(Vec3::splat(8.0_f32)),
-        ..default()
-    });
+    commands.spawn((
+        PointLight::default(),
+        Transform::from_translation(Vec3::splat(8.0_f32)),
+    ));
 
     // Main render pass camera with parented render textures
     commands
         .spawn(default_cube::camera_bundle())
         .with_children(|parent| {
             // Top render texture, looking at a grid
-            parent.spawn(PbrBundle {
-                mesh: meshes.add(Mesh::from(Cuboid::new(0.25_f32, 0.25, 0.25))),
-                material: materials.add(StandardMaterial {
+            parent.spawn((
+                Mesh3d(meshes.add(Mesh::from(Cuboid::new(0.25_f32, 0.25, 0.25)))),
+                MeshMaterial3d(materials.add(StandardMaterial {
                     base_color_texture: Some(top_image_handle),
                     unlit: true,
                     double_sided: true,
                     ..default()
-                }),
-                transform: Transform::from_xyz(0.5_f32, 0.2_f32, -1.0_f32)
-                    .looking_at(Vec3::ZERO, Vec3::Y),
-                ..default()
-            });
+                })),
+                Transform::from_xyz(0.5_f32, 0.2_f32, -1.0_f32).looking_at(Vec3::ZERO, Vec3::Y),
+            ));
             // Bottom render texture, looking at a tracked grid
-            parent.spawn(PbrBundle {
-                mesh: meshes.add(Mesh::from(Cuboid::new(0.25_f32, 0.25, 0.25))),
-                material: materials.add(StandardMaterial {
+            parent.spawn((
+                Mesh3d(meshes.add(Mesh::from(Cuboid::new(0.25_f32, 0.25, 0.25)))),
+                MeshMaterial3d(materials.add(StandardMaterial {
                     base_color_texture: Some(bottom_image_handle),
                     unlit: true,
                     double_sided: true,
                     ..default()
-                }),
-                transform: Transform::from_xyz(0.5_f32, -0.2_f32, -1.0_f32)
-                    .looking_at(Vec3::ZERO, Vec3::Y),
-                ..default()
-            });
+                })),
+                Transform::from_xyz(0.5_f32, -0.2_f32, -1.0_f32).looking_at(Vec3::ZERO, Vec3::Y),
+            ));
         });
 }
 
 // System for moving the entities with the Floating component
 fn floating_object(time: Res<Time>, mut query: Query<&mut Transform, With<Floating>>) {
     for mut transform in &mut query {
-        transform.translation.y += (time.elapsed_seconds() * 2.0_f32).sin() * 0.004_f32;
-        transform.rotate_y(time.delta_seconds() * 0.75_f32);
+        transform.translation.y += (time.elapsed_secs() * 2.0_f32).sin() * 0.004_f32;
+        transform.rotate_y(time.elapsed_secs() * 0.75_f32);
     }
 }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -15,8 +15,8 @@ pub fn spawn_floor_grid(mut commands: Commands) {
         SubGrid::default(),
         GridAxis::new_rgb(),
         TrackedGrid::default(),
-        TransformBundle::default(),
-        VisibilityBundle::default(),
+        Transform::default(),
+        Visibility::default(),
     ));
 }
 

--- a/src/rendering.rs
+++ b/src/rendering.rs
@@ -1,15 +1,15 @@
 use bevy::{
+    pbr::{MaterialPipeline, MaterialPipelineKey},
     prelude::*,
     reflect::TypePath,
-    pbr::{MaterialPipeline, MaterialPipelineKey},
     render::{
-        texture::GpuImage,
         mesh::MeshVertexBufferLayoutRef,
         render_asset::RenderAssets,
         render_resource::{
             AsBindGroup, AsBindGroupShaderType, PolygonMode, RenderPipelineDescriptor, ShaderRef,
             ShaderType, SpecializedMeshPipelineError,
         },
+        texture::GpuImage,
     },
 };
 

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -87,11 +87,14 @@ pub fn main_grid_mesher_untracked(
         commands.entity(entity).with_children(|children| {
             let mut commands = children.spawn((
                 GridChild,
-                meshes.add(mesh),
+                Mesh3d(meshes.add(mesh)),
                 NotShadowCaster,
-                TransformBundle::default(),
-                VisibilityBundle::default(),
-                simple_materials.add(SimpleLineMaterial::from_color(grid.color, grid.alpha_mode)),
+                Transform::default(),
+                Visibility::default(),
+                MeshMaterial3d(
+                    simple_materials
+                        .add(SimpleLineMaterial::from_color(grid.color, grid.alpha_mode)),
+                ),
             ));
             if let Some(render_layers) = render_layers {
                 commands.insert(render_layers.clone());
@@ -140,18 +143,18 @@ pub fn main_grid_mesher_tracked(
         commands.entity(entity).with_children(|children| {
             let mut commands = children.spawn((
                 GridChild,
-                meshes.add(mesh),
+                Mesh3d(meshes.add(mesh)),
                 NotShadowCaster,
-                TransformBundle::default(),
-                VisibilityBundle::default(),
-                clipped_materials.add(ClippedLineMaterial::new(
+                Transform::default(),
+                Visibility::default(),
+                MeshMaterial3d(clipped_materials.add(ClippedLineMaterial::new(
                     grid.color,
                     grid.alpha_mode,
                     tracked.alignment,
                     size - grid.spacing,
                     tracked.offset,
                     axis,
-                )),
+                ))),
             ));
             if let Some(render_layers) = render_layers {
                 commands.insert(render_layers.clone());
@@ -163,18 +166,18 @@ pub fn main_grid_mesher_tracked(
                 axis_mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, vertices);
                 let mut commands = children.spawn((
                     GridChild,
-                    meshes.add(axis_mesh),
+                    Mesh3d(meshes.add(axis_mesh)),
                     NotShadowCaster,
                     GlobalTransform::default(),
-                    VisibilityBundle::default(),
-                    clipped_materials.add(ClippedLineMaterial::new(
+                    Visibility::default(),
+                    MeshMaterial3d(clipped_materials.add(ClippedLineMaterial::new(
                         color,
                         grid.alpha_mode,
                         tracked.alignment,
                         size - grid.spacing,
                         tracked.offset,
                         None,
-                    )),
+                    ))),
                 ));
                 if let Some(render_layers) = render_layers {
                     commands.insert(render_layers.clone());
@@ -232,26 +235,28 @@ pub fn sub_grid_mesher(
         commands.entity(entity).with_children(|children| {
             let mut child_commands = children.spawn((
                 SubGridChild,
-                meshes.add(mesh),
+                Mesh3d(meshes.add(mesh)),
                 NotShadowCaster,
-                TransformBundle::from_transform(Transform::from_translation(
+                Transform::from_translation(
                     alignment.shift_vec3(-Vec3::Y * SUB_GRID_VERTICAL_OFFSET),
-                )),
-                VisibilityBundle::default(),
+                ),
+                Visibility::default(),
             ));
             if let Some(tracked) = tracked {
-                child_commands.insert(clipped_materials.add(ClippedLineMaterial::new(
-                    sub_grid.color,
-                    grid.alpha_mode,
-                    tracked.alignment,
-                    size - grid.spacing,
-                    tracked.offset,
-                    None,
+                child_commands.insert(MeshMaterial3d(clipped_materials.add(
+                    ClippedLineMaterial::new(
+                        sub_grid.color,
+                        grid.alpha_mode,
+                        tracked.alignment,
+                        size - grid.spacing,
+                        tracked.offset,
+                        None,
+                    ),
                 )));
             } else {
-                child_commands.insert(
-                    simple_materials.add(SimpleLineMaterial::from_color(sub_grid.color, grid.alpha_mode)),
-                );
+                child_commands.insert(MeshMaterial3d(simple_materials.add(
+                    SimpleLineMaterial::from_color(sub_grid.color, grid.alpha_mode),
+                )));
             }
             if let Some(render_layers) = render_layers {
                 child_commands.insert(render_layers.clone());
@@ -299,11 +304,14 @@ pub fn grid_axis_mesher(
                     );
                     let mut commands = children.spawn((
                         GridAxisChild,
-                        meshes.add(mesh),
+                        Mesh3d(meshes.add(mesh)),
                         NotShadowCaster,
-                        TransformBundle::default(),
-                        VisibilityBundle::default(),
-                        simple_materials.add(SimpleLineMaterial::from_color(color, grid.alpha_mode)),
+                        Transform::default(),
+                        Visibility::default(),
+                        MeshMaterial3d(
+                            simple_materials
+                                .add(SimpleLineMaterial::from_color(color, grid.alpha_mode)),
+                        ),
                     ));
                     if let Some(render_layers) = render_layers {
                         commands.insert(render_layers.clone());
@@ -322,11 +330,14 @@ pub fn grid_axis_mesher(
                 mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, vertices);
                 let mut commands = children.spawn((
                     GridAxisChild,
-                    meshes.add(mesh),
+                    Mesh3d(meshes.add(mesh)),
                     NotShadowCaster,
-                    TransformBundle::default(),
-                    VisibilityBundle::default(),
-                    simple_materials.add(SimpleLineMaterial::from_color(grid.color, grid.alpha_mode)),
+                    Transform::default(),
+                    Visibility::default(),
+                    MeshMaterial3d(
+                        simple_materials
+                            .add(SimpleLineMaterial::from_color(grid.color, grid.alpha_mode)),
+                    ),
                 ));
                 if let Some(render_layers) = render_layers {
                     commands.insert(render_layers.clone());


### PR DESCRIPTION
Updates the package to Bevy 0.15. This involved a bunch of small changes, mostly around the new bundle syntax.
* Migrated default Bundles to Components where deprecated
* Wrapped mesh handles in Mesh3d
* Wrapped material handles in MeshMaterial3d

Source and examples are all updated!