### PR TITLE
Migrate src to bevy 0.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,20 +6,17 @@ repository = "https://github.com/romenjelly/bevy_debug_grid"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
-exclude = [
-    "/examples/",
-    "/assets/",
-]
+exclude = ["/examples/", "/assets/"]
 
 [dependencies]
-bevy = { version = "0.15", default-features = false, features = [
+bevy = { version = "0.16", default-features = false, features = [
     "bevy_render",
     "bevy_pbr",
     "bevy_asset",
 ] }
 
 [dev-dependencies]
-bevy = "0.15"
+bevy = "0.16"
 bevy_spectator = "0.7.0"
 
 [[example]]

--- a/src/rendering.rs
+++ b/src/rendering.rs
@@ -1,5 +1,5 @@
+use bevy::asset::weak_handle;
 #[allow(unused_imports)]
-
 use bevy::{
     asset::{Asset, Handle},
     pbr::{MaterialPipeline, MaterialPipelineKey},
@@ -16,7 +16,8 @@ use bevy::{
 };
 
 /// Handle for the clipped line shader
-pub const CLIPPED_LINE_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(14735426461149675473);
+pub const CLIPPED_LINE_SHADER_HANDLE: Handle<Shader> =
+    weak_handle!("66CF2528-BE11-4875-9A37-218FB089E67D");
 
 use crate::{GridAlignment, GridAxis};
 
@@ -111,7 +112,8 @@ impl Material for ClippedLineMaterial {
 }
 
 /// Handle for the simple line shader
-pub const SIMPLE_LINE_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(14181856097290587572);
+pub const SIMPLE_LINE_SHADER_HANDLE: Handle<Shader> =
+    weak_handle!("3E41FD75-3AEA-4B8A-B2CE-6AE5A32973F4");
 
 /// Simple line material with no functionality beyond assigning a color
 #[derive(Default, Asset, AsBindGroup, TypePath, Debug, Clone)]

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -1,11 +1,11 @@
 #![allow(clippy::type_complexity)]
 
 use bevy::pbr::NotShadowCaster;
+use bevy::platform::collections::HashMap;
 use bevy::prelude::*;
 use bevy::render::render_asset::RenderAssetUsages;
 use bevy::render::render_resource::PrimitiveTopology;
 use bevy::render::view::RenderLayers;
-use bevy::utils::HashMap;
 
 use crate::*;
 
@@ -364,7 +364,7 @@ pub fn tracked_grid_updater<T: Component>(
     mut floor_grid_query: Query<(&mut Transform, &Grid, &TrackedGrid)>,
     tracked_transform_query: Query<&GlobalTransform, (With<T>, Without<TrackedGrid>)>,
 ) {
-    let Ok(tracked_transform) = tracked_transform_query.get_single() else {
+    let Ok(tracked_transform) = tracked_transform_query.single() else {
         return;
     };
     for (mut grid_transform, grid, tracked) in floor_grid_query.iter_mut() {
@@ -401,16 +401,16 @@ pub fn custom_tracked_grid_updater(
 /// Despawns children with a marker component upon the removal of their parent
 pub fn despawn_children_upon_removal<RemovedParent: Component, ChildMarker: Component>(
     mut removed: RemovedComponents<RemovedParent>,
-    query: Query<(&Parent, Entity), With<ChildMarker>>,
+    query: Query<(&ChildOf, Entity), With<ChildMarker>>,
     mut commands: Commands,
 ) {
     if removed.is_empty() {
         return;
     }
     let mut parent_to_child_map: HashMap<Entity, Vec<Entity>> = HashMap::new();
-    for (parent, child) in query.iter() {
+    for (child_of, child) in query.iter() {
         parent_to_child_map
-            .entry(parent.get())
+            .entry(child_of.parent())
             .and_modify(|children| children.push(child))
             .or_insert_with(|| vec![child]);
     }


### PR DESCRIPTION
Here are the changes necessary to migrate to `0.16` of `bevy`. 
Examples will not work until `bevy_spectator` dependency is updated.