### PR TITLE
Upgrade to Bevy 0.18

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,14 +9,14 @@ keywords = ["bevy"]
 exclude = ["/examples/", "/assets/"]
 
 [dependencies]
-bevy = { version = "0.17", default-features = false, features = [
-    "bevy_render",
-    "bevy_pbr",
-    "bevy_asset",
+bevy = { version = "0.18", default-features = false, features = [
+  "bevy_render",
+  "bevy_pbr",
+  "bevy_asset",
 ] }
 
 [dev-dependencies]
-bevy = "0.17"
+bevy = "0.18"
 
 [[example]]
 name = "default_cube"

--- a/examples/changing_grid.rs
+++ b/examples/changing_grid.rs
@@ -1,4 +1,4 @@
-use bevy::{prelude::*, color::palettes::tailwind};
+use bevy::{color::palettes::tailwind, prelude::*};
 use bevy_debug_grid::*;
 use std::f32;
 

--- a/examples/default_cube.rs
+++ b/examples/default_cube.rs
@@ -2,11 +2,7 @@ use bevy::prelude::*;
 use bevy_debug_grid::*;
 
 #[allow(unused_imports)]
-pub use camera_controller::{
-    CameraControllerPlugin,
-    camera_bundle,
-    ControlledCamera,
-};
+pub use camera_controller::{camera_bundle, CameraControllerPlugin, ControlledCamera};
 
 #[allow(dead_code)]
 fn main() {
@@ -42,8 +38,8 @@ fn default_cube(
 
 // Camera controller used by every example
 pub mod camera_controller {
-    use bevy::prelude::*;
     use bevy::input::mouse::MouseMotion;
+    use bevy::prelude::*;
     use bevy::window::CursorOptions;
 
     #[derive(Component)]
@@ -60,7 +56,6 @@ pub mod camera_controller {
     impl CameraControllerPlugin {
         pub const DEFAULT_CAMERA_ORIGIN: Vec3 = Vec3::new(7.0_f32, 3.5_f32, 4.0_f32);
         pub const DEFAULT_CAMERA_LOOK_AT: Vec3 = Vec3::new(0.0_f32, 0.5_f32, 0.0_f32);
-
 
         pub fn without_camera() -> Self {
             Self {
@@ -95,20 +90,12 @@ pub mod camera_controller {
             if let Some(camera_transform) = self.camera_transform {
                 app.add_systems(Startup, spawn_camera(camera_transform));
             }
-            app.add_systems(Update, (
-                handle_focus,
-                translate_camera,
-                rotate_camera,
-            ));
+            app.add_systems(Update, (handle_focus, translate_camera, rotate_camera));
         }
     }
 
     pub fn camera_bundle(camera_transform: Transform) -> impl Bundle {
-        (
-            Camera3d::default(),
-            ControlledCamera,
-            camera_transform,
-        )
+        (Camera3d::default(), ControlledCamera, camera_transform)
     }
 
     fn spawn_camera(camera_transform: Transform) -> impl Fn(Commands) {
@@ -152,11 +139,12 @@ pub mod camera_controller {
             8.0_f32
         };
 
-        let mut translation_intent = transform.rotation * Vec3::new(
-            axis_motion_intent(KeyCode::KeyD, KeyCode::KeyA),
-            0.0_f32,
-            axis_motion_intent(KeyCode::KeyS, KeyCode::KeyW),
-        );
+        let mut translation_intent = transform.rotation
+            * Vec3::new(
+                axis_motion_intent(KeyCode::KeyD, KeyCode::KeyA),
+                0.0_f32,
+                axis_motion_intent(KeyCode::KeyS, KeyCode::KeyW),
+            );
         translation_intent.y = 0.0_f32;
         translation_intent = translation_intent.normalize_or_zero();
         translation_intent.y = axis_motion_intent(KeyCode::Space, KeyCode::ControlLeft);

--- a/examples/dynamic_floor_grid.rs
+++ b/examples/dynamic_floor_grid.rs
@@ -1,4 +1,4 @@
-use bevy::{prelude::*, color::palettes::tailwind};
+use bevy::{color::palettes::tailwind, prelude::*};
 use bevy_debug_grid::*;
 
 mod default_cube;
@@ -19,10 +19,7 @@ fn main() {
             default_cube::CameraControllerPlugin::default(),
             DebugGridPlugin::without_floor_grid(),
         ))
-        .add_systems(
-            Startup,
-            (spawn_floor_grid, spawn_center_sphere),
-        )
+        .add_systems(Startup, (spawn_floor_grid, spawn_center_sphere))
         .add_systems(Update, (move_floor_grid, change_axis_color))
         .run();
 }
@@ -75,7 +72,11 @@ fn move_floor_grid(mut query: Query<&mut TrackedGrid>, time: Res<Time>) {
 }
 
 fn lerp_color(lhs: Srgba, rhs: Srgba, factor: f32) -> Color {
-    let subbed = Srgba::rgb(rhs.red - lhs.red, rhs.green - lhs.green, rhs.blue - lhs.blue);
+    let subbed = Srgba::rgb(
+        rhs.red - lhs.red,
+        rhs.green - lhs.green,
+        rhs.blue - lhs.blue,
+    );
     Color::Srgba(lhs + subbed * factor)
 }
 

--- a/examples/moving_grid.rs
+++ b/examples/moving_grid.rs
@@ -1,4 +1,4 @@
-use bevy::{prelude::*, color::palettes::tailwind};
+use bevy::{color::palettes::tailwind, prelude::*};
 use bevy_debug_grid::*;
 use std::f32;
 

--- a/examples/render_layers.rs
+++ b/examples/render_layers.rs
@@ -1,7 +1,10 @@
 use bevy::{
-    prelude::*,
-    camera::{visibility::{Layer, RenderLayers}, RenderTarget},
+    camera::{
+        visibility::{Layer, RenderLayers},
+        RenderTarget,
+    },
     color::palettes::tailwind,
+    prelude::*,
     render::render_resource::{
         Extent3d, TextureDescriptor, TextureDimension, TextureFormat, TextureUsages,
     },
@@ -85,9 +88,9 @@ fn setup(
         Camera {
             clear_color: ClearColorConfig::Custom(Color::Srgba(tailwind::GRAY_500)),
             order: -1,
-            target: RenderTarget::Image(top_image_handle.clone().into()),
             ..default()
         },
+        RenderTarget::Image(top_image_handle.clone().into()),
         Transform::from_xyz(0.0_f32, 8.0_f32, 0.0_f32).looking_at(Vec3::ZERO, Vec3::Y),
         RenderLayers::layer(TOP_LAYER),
     ));
@@ -114,9 +117,9 @@ fn setup(
             Camera {
                 clear_color: ClearColorConfig::Custom(Color::Srgba(tailwind::GRAY_500)),
                 order: -1,
-                target: RenderTarget::Image(bottom_image_handle.clone().into()),
                 ..default()
             },
+            RenderTarget::Image(bottom_image_handle.clone().into()),
             Transform::from_xyz(-4.0_f32, 2.0_f32, 4.0_f32).looking_at(Vec3::Y, Vec3::Y),
             RenderLayers::layer(BOTTOM_LAYER),
         ))

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -1,11 +1,11 @@
 #![allow(clippy::type_complexity)]
 
+use bevy::asset::RenderAssetUsages;
+use bevy::camera::visibility::RenderLayers;
 use bevy::light::NotShadowCaster;
 use bevy::platform::collections::HashMap;
 use bevy::prelude::*;
-use bevy::asset::RenderAssetUsages;
 use bevy::render::render_resource::PrimitiveTopology;
-use bevy::camera::visibility::RenderLayers;
 
 use crate::*;
 
@@ -27,7 +27,7 @@ fn despawn_children_of_type<T: Component>(
         .into_iter()
         .filter_map(|child| query.get(*child).ok())
         .collect::<Vec<_>>();
-    commands.entity(parent).remove_children(&children);
+    commands.entity(parent).detach_children(&children);
     for child in children {
         commands.entity(child).despawn();
     }


### PR DESCRIPTION
## Summary
- Update bevy dependency from 0.17 to 0.18 in both `[dependencies]` and `[dev-dependencies]`
- Replace deprecated `remove_children()` with `detach_children()` in systems.rs
- Move `RenderTarget` from `Camera` field to separate component in render_layers example

## Test plan
- [x] Library builds successfully
- [x] All examples compile and run